### PR TITLE
Add a bootstrap script, improve Makefile.am and configure.ac

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 AUTOMAKE_OPTIONS = subdir-objects
+ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES=liborientdb-c.la
 

--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,6 @@
+#! /bin/sh
+aclocal \
+&& libtoolize \
+&& autoheader \
+&& automake --gnu --add-missing \
+&& autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_INIT([orientdb-c],[0.9])
 AC_CONFIG_SRCDIR([src/o_query_internal.h])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE()
+AC_CONFIG_MACRO_DIR([m4])
 
 LT_INIT([disable-static])
 # Checks for programs.


### PR DESCRIPTION
This should make the project more easily configurable. Otherwise, people have to figure out the content of a bootstrap script. I've added the extra lines in the project config files following the suggestions of the gnu tools.
